### PR TITLE
RFC: Removing Ring Shuffling (please vote)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,17 +211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,12 +499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,36 +514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -856,8 +809,6 @@ name = "umaring"
 version = "0.1.0"
 dependencies = [
  "axum",
- "rand",
- "rand_chacha",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,7 @@ edition = "2021"
 [dependencies]
 axum = { version = "0.7.4", features = ["macros"] }
 tower-http = { version = "0.5.0", features = ["cors"] }
-rand = "0.8.5"
 serde = { version = "1.0.173", features = ["derive"] }
 serde_json = "1.0.103"
 tokio = { version = "1.35.1", features = ["full"] }
 toml = "0.8.9"
-rand_chacha = "0.3.1"

--- a/members.toml
+++ b/members.toml
@@ -1,4 +1,9 @@
 [[users]]
+id = "tbo"
+name = "Shanyu Thibaut Juneja"
+url = "https://ghast.dev"
+
+[[users]]
 id = "haylin"
 name = "Haylin Moore"
 url = "https://hayl.in"
@@ -22,11 +27,6 @@ url = "https://skushagra.com"
 id = "rporta"
 name = "Rose Porta"
 url = "https://roseporta.com"
-
-[[users]]
-id = "tbo"
-name = "Shanyu Thibaut Juneja"
-url = "https://ghast.dev"
 
 [[users]]
 id = "s3gfault"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,17 +15,6 @@ async fn main() {
 
     let ring = Arc::new(RwLock::new(ring));
 
-    let ring_clone = ring.clone();
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(tokio::time::Duration::from_secs(60 * 60)).await;
-
-            let mut ring = ring_clone.write().await;
-
-            ring.shuffle();
-        }
-    });
-
     let app = Router::new()
         .route(
             "/",

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,7 +1,4 @@
-use rand::{seq::SliceRandom, SeedableRng};
-use rand_chacha::ChaChaRng;
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Member {
@@ -25,29 +22,12 @@ impl Ring {
         let ring_source: RingSource = toml::from_str(toml).unwrap();
         let users = ring_source.users;
 
-        let mut ring = Self {
-            mapping: vec![],
+        let mapping: Vec<usize> = (0..users.len()).collect();
+
+        Self {
+            mapping,
             members: users,
-        };
-
-        ring.shuffle();
-
-        ring
-    }
-
-    pub fn shuffle(&mut self) {
-        let epoch = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or(Duration::new(1, 0))
-            .as_secs()
-            / (60 * 60 * 24 * 7); // Seed is weeks since 1970
-
-        let mut rng = ChaChaRng::seed_from_u64(epoch);
-
-        let mut mapping: Vec<usize> = (0..self.members.len()).collect();
-        mapping.shuffle(&mut rng);
-
-        self.mapping = mapping;
+        }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Member> {

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -9,7 +9,6 @@ pub struct Member {
 
 pub struct Ring {
     members: Vec<Member>,
-    mapping: Vec<usize>,
 }
 
 #[derive(Deserialize)]
@@ -22,29 +21,23 @@ impl Ring {
         let ring_source: RingSource = toml::from_str(toml).unwrap();
         let users = ring_source.users;
 
-        let mapping: Vec<usize> = (0..users.len()).collect();
-
-        Self {
-            mapping,
-            members: users,
-        }
+        Self { members: users }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Member> {
-        let len = self.members.len();
-        (0..len).map(move |i| &self.members[self.mapping[i % len]])
+        self.members.iter()
     }
 
     pub fn get(&self, id: &str) -> Option<&Member> {
-        self.iter().find(|m| m.id == id)
+        self.members.iter().find(|m| m.id == id)
     }
 
     pub fn neighbors(&self, id: &str) -> Option<(&Member, &Member)> {
-        let index = self.iter().position(|m| m.id == id)?;
+        let index = self.members.iter().position(|m| m.id == id)?;
+        let len = self.members.len();
 
-        let prev =
-            &self.members[self.mapping[(index + self.members.len() - 1) % self.members.len()]];
-        let next = &self.members[self.mapping[(index + 1) % self.members.len()]];
+        let prev = &self.members[(index + len - 1) % len];
+        let next = &self.members[(index + 1) % len];
 
         Some((prev, next))
     }


### PR DESCRIPTION
I am currently toying with the idea of removing shuffling from the webring.

I feel that this makes sense because currently the webring gets broken temporarily during every shuffle event, because of the users that cache their positions and neighbors server-side. This server-side loading and caching is in my opinion a good pattern as it lowers requests to the back-end, increases anonymity for people browsing sites on the ring, and lets members have sites that load without extra Javascript. Servers could make a new request to umaring on each request, but that would be blocking.

In addition, randomization of a ring is also not a very common practice from what I can tell, and it simplifies the ring's code (my current PR could even be cleaned up more to be faster).

Thoughts? I think a justification could be made for keeping randomization if people think it's cool, I'm just meh about it, and have gotten a few reports of ring breakage that I suspect were due to it as they were ephemeral. 

EDIT: A benefit of ring randomization is it forces people to connect to the ring properly, we find out rather fast if they have hard coded in their links on their site.